### PR TITLE
Clear arrays

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+﻿[*.cs]
+
+# CS1591: Missing XML comment for publicly visible type or member
+dotnet_diagnostic.CS1591.severity = none

--- a/Skynet.sln
+++ b/Skynet.sln
@@ -15,6 +15,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Skynet.Core.Tests", "tests\
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_", "_", "{1A7D56C5-2B1A-4CA6-BF5F-7B3891E14A02}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		azure-pipelines.yml = azure-pipelines.yml
 		nuget.config = nuget.config
 		README.md = README.md

--- a/src/Skynet.Core/Network/PacketBuffer.cs
+++ b/src/Skynet.Core/Network/PacketBuffer.cs
@@ -84,6 +84,9 @@ namespace Skynet.Network
             }
         }
 
+        /// <summary>
+        /// Returns the internal buffer. If you want take ownership call <see cref="GetBufferAndDispose"/> instead.
+        /// </summary>
         public ReadOnlyMemory<byte> GetBuffer()
         {
             if (disposed) throw new ObjectDisposedException(nameof(PacketBuffer));
@@ -442,6 +445,10 @@ namespace Skynet.Network
             }
         }
 
+        /// <summary>
+        /// Returns the internal buffer and disposes this <see cref="PacketBuffer"/>
+        /// whithout clearing or freeing its buffer.
+        /// </summary>
         public PoolableMemory GetBufferAndDispose()
         {
             if (disposed) throw new ObjectDisposedException(nameof(PacketBuffer));

--- a/src/Skynet.Core/Network/PacketBuffer.cs
+++ b/src/Skynet.Core/Network/PacketBuffer.cs
@@ -91,13 +91,6 @@ namespace Skynet.Network
             return buffer.Slice(0, position);
         }
 
-        public Memory<byte> GetInternalBuffer()
-        {
-            if (disposed) throw new ObjectDisposedException(nameof(PacketBuffer));
-
-            return buffer;
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void PrepareRead(int length)
         {
@@ -447,6 +440,15 @@ namespace Skynet.Network
 
                 disposed = true;
             }
+        }
+
+        public PoolableMemory GetBufferAndDispose()
+        {
+            if (disposed) throw new ObjectDisposedException(nameof(PacketBuffer));
+
+            disposed = true;
+
+            return new PoolableMemory(buffer.Slice(0, position), rented);
         }
     }
 }

--- a/src/Skynet.Core/Network/PoolableMemory.cs
+++ b/src/Skynet.Core/Network/PoolableMemory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Buffers;
+using System.Runtime.InteropServices;
 
 namespace Skynet.Network
 {
@@ -25,9 +26,15 @@ namespace Skynet.Network
             }
         }
 
-        public PoolableMemory(Memory<byte> memory, byte[]? rentedBuffer)
+        public PoolableMemory(Memory<byte> memory, byte[]? rentedBuffer = null)
         {
             Memory = memory;
+            RentedBuffer = rentedBuffer;
+        }
+
+        public PoolableMemory(ReadOnlyMemory<byte> memory, byte[]? rentedBuffer = null)
+        {
+            Memory = MemoryMarshal.AsMemory(memory);
             RentedBuffer = rentedBuffer;
         }
 

--- a/src/Skynet.Core/Network/PoolableMemory.cs
+++ b/src/Skynet.Core/Network/PoolableMemory.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Buffers;
+
+namespace Skynet.Network
+{
+    public readonly struct PoolableMemory
+    {
+        // ArrayPool is faster for large arrays: https://adamsitnik.com/Array-Pool/
+
+        private const int RentMinSize = 1024;
+
+        public static PoolableMemory Allocate(int length, bool exactly)
+        {
+            if (length >= RentMinSize)
+            {
+                byte[] rented = ArrayPool<byte>.Shared.Rent(length);
+                if (exactly)
+                    return new PoolableMemory(new Memory<byte>(rented, 0, length), rented);
+                else
+                    return new PoolableMemory(rented, rented);
+            }
+            else
+            {
+                return new PoolableMemory(new byte[length], null);
+            }
+        }
+
+        public PoolableMemory(Memory<byte> memory, byte[]? rentedBuffer)
+        {
+            Memory = memory;
+            RentedBuffer = rentedBuffer;
+        }
+
+        public Memory<byte> Memory { get; }
+        public byte[]? RentedBuffer { get; }
+
+        public void Return(bool clearMemory)
+        {
+            if (RentedBuffer != null)
+            {
+                ArrayPool<byte>.Shared.Return(RentedBuffer, clearMemory);
+            }
+            else
+            {
+                Memory.Span.Clear();
+            }
+        }
+    }
+}

--- a/src/Skynet.Core/Network/PoolableMemory.cs
+++ b/src/Skynet.Core/Network/PoolableMemory.cs
@@ -4,6 +4,9 @@ using System.Runtime.InteropServices;
 
 namespace Skynet.Network
 {
+    /// <summary>
+    /// Represents a byte array that may be rented from an <see cref="ArrayPool{T}"/>.
+    /// </summary>
     public readonly struct PoolableMemory
     {
         // ArrayPool is faster for large arrays: https://adamsitnik.com/Array-Pool/

--- a/src/Skynet.Core/Skynet.Core.csproj
+++ b/src/Skynet.Core/Skynet.Core.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Skynet</RootNamespace>
     <Nullable>enable</Nullable>
     <Copyright>© 2017-2020 Daniel Lerch</Copyright>
-    <Version>5.2.0</Version>
+    <Version>5.2.1</Version>
     <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
     <Authors>Daniel Lerch</Authors>
     <RepositoryUrl>https://github.com/skynet-im/skynet-dotnet</RepositoryUrl>

--- a/src/Skynet.Core/Skynet.Core.csproj
+++ b/src/Skynet.Core/Skynet.Core.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>Skynet</RootNamespace>
     <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Copyright>© 2017-2020 Daniel Lerch</Copyright>
     <Version>5.2.1</Version>
     <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/Skynet.Protocol/ChannelMessage.cs
+++ b/src/Skynet.Protocol/ChannelMessage.cs
@@ -42,7 +42,7 @@ namespace Skynet.Protocol
 
             byte[] hmacKey = key.Slice(0, 32).ToArray();
             byte[] aesKey = key.Slice(32, 32).ToArray();
-            ReadContent(AesStatic.DecryptWithHmac(contentBuffer.Value.Memory, hmacKey, aesKey));
+            ReadContent(AesStatic.DecryptWithHmac(contentBuffer.Value.Memory, hmacKey, aesKey), clearBuffer: true);
             Array.Clear(hmacKey, 0, 32);
             Array.Clear(aesKey, 0, 32);
         }
@@ -91,7 +91,7 @@ namespace Skynet.Protocol
 
             if (MessageFlags.HasFlag(MessageFlags.Unencrypted))
             {
-                ReadContent(contentBuffer.Value.Memory);
+                ReadContent(contentBuffer.Value.Memory, clearBuffer: false);
             }
 
             int length = buffer.ReadUInt16();
@@ -154,9 +154,9 @@ namespace Skynet.Protocol
         protected virtual void ReadMessage(PacketBuffer buffer) { }
         protected virtual void WriteMessage(PacketBuffer buffer) { }
 
-        private void ReadContent(ReadOnlyMemory<byte> buffer)
+        private void ReadContent(ReadOnlyMemory<byte> buffer, bool clearBuffer)
         {
-            using var contentBuffer = new PacketBuffer(buffer);
+            using var contentBuffer = new PacketBuffer(buffer, clearBuffer);
             ReadMessage(contentBuffer);
             if (MessageFlags.HasFlag(MessageFlags.MediaMessage))
                 File = new ChannelMessageFile(contentBuffer, MessageFlags.HasFlag(MessageFlags.ExternalFile));

--- a/src/Skynet.Protocol/ChannelMessage.cs
+++ b/src/Skynet.Protocol/ChannelMessage.cs
@@ -42,7 +42,7 @@ namespace Skynet.Protocol
 
             byte[] hmacKey = key.Slice(0, 32).ToArray();
             byte[] aesKey = key.Slice(32, 32).ToArray();
-            ReadContent(AesStatic.EncryptWithHmac(contentBuffer.Value.Memory, hmacKey, aesKey));
+            ReadContent(AesStatic.DecryptWithHmac(contentBuffer.Value.Memory, hmacKey, aesKey));
             Array.Clear(hmacKey, 0, 32);
             Array.Clear(aesKey, 0, 32);
         }

--- a/src/Skynet.Protocol/ChannelMessageFile.cs
+++ b/src/Skynet.Protocol/ChannelMessageFile.cs
@@ -27,7 +27,7 @@ namespace Skynet.Protocol
             {
                 ContentType = buffer.ReadShortString();
                 Length = buffer.ReadInt64();
-                Key = buffer.ReadRawByteArray(32).ToArray();
+                Key = buffer.ReadByteArray(32);
             }
         }
 
@@ -43,7 +43,7 @@ namespace Skynet.Protocol
             {
                 buffer.WriteShortString(ContentType);
                 buffer.WriteInt64(Length);
-                buffer.WriteRawByteArray(Key);
+                buffer.WriteByteArray(Key);
             }
         }
     }

--- a/src/Skynet.Protocol/Cryptography/AesStatic.cs
+++ b/src/Skynet.Protocol/Cryptography/AesStatic.cs
@@ -8,6 +8,13 @@ namespace Skynet.Protocol.Cryptography
     {
         private static readonly Aes aes = Aes.Create();
 
+        /// <summary>
+        /// Encrypts a message with a random IV and AES-256-CBC and computes its HMAC-SHA-256 digest.
+        /// The output order is HMAC (32 byte), IV (16 byte), ciphertext.
+        /// </summary>
+        /// <param name="plaintext"></param>
+        /// <param name="hmacKey">A 256 bit key for HMAC-SHA-256 message digest calculation.</param>
+        /// <param name="aesKey">A 256 bit key for AES-256-CBC encryption.</param>
         public static ReadOnlyMemory<byte> EncryptWithHmac(ReadOnlyMemory<byte> plaintext, byte[] hmacKey, byte[] aesKey)
         {
             if (hmacKey == null) throw new ArgumentNullException(nameof(hmacKey));
@@ -38,6 +45,12 @@ namespace Skynet.Protocol.Cryptography
             return ciphertext;
         }
 
+        /// <summary>
+        /// Decrypts a message using AES-256-CBC and verifies its HMAC-SHA-256 digest.
+        /// </summary>
+        /// <param name="ciphertext">A buffer containing an HMAC (32 byte), IV (16 byte) and at least one AES-encrypted block.</param>
+        /// <param name="hmacKey">A 256 bit key for HMAC-SHA-256 message digest calculation.</param>
+        /// <param name="aesKey">A 256 bit key for AES-256-CBC encryption.</param>
         public static ReadOnlyMemory<byte> DecryptWithHmac(ReadOnlyMemory<byte> ciphertext, byte[] hmacKey, byte[] aesKey)
         {
             if (hmacKey == null) throw new ArgumentNullException(nameof(hmacKey));

--- a/src/Skynet.Protocol/Packets/P02CreateAccount.cs
+++ b/src/Skynet.Protocol/Packets/P02CreateAccount.cs
@@ -16,13 +16,13 @@ namespace Skynet.Protocol.Packets
         protected override void ReadPacketInternal(PacketBuffer buffer, PacketRole role)
         {
             AccountName = buffer.ReadShortString();
-            KeyHash = buffer.ReadRawByteArray(32).ToArray();
+            KeyHash = buffer.ReadByteArray(32);
         }
 
         protected override void WritePacketInternal(PacketBuffer buffer, PacketRole role)
         {
             buffer.WriteShortString(AccountName);
-            buffer.WriteRawByteArray(KeyHash);
+            buffer.WriteByteArray(KeyHash);
         }
 
         public override string ToString()

--- a/src/Skynet.Protocol/Packets/P04DeleteAccount.cs
+++ b/src/Skynet.Protocol/Packets/P04DeleteAccount.cs
@@ -14,12 +14,12 @@ namespace Skynet.Protocol.Packets
 
         protected override void ReadPacketInternal(PacketBuffer buffer, PacketRole role)
         {
-            KeyHash = buffer.ReadRawByteArray(32).ToArray();
+            KeyHash = buffer.ReadByteArray(32);
         }
 
         protected override void WritePacketInternal(PacketBuffer buffer, PacketRole role)
         {
-            buffer.WriteRawByteArray(KeyHash);
+            buffer.WriteByteArray(KeyHash);
         }
     }
 }

--- a/src/Skynet.Protocol/Packets/P06CreateSession.cs
+++ b/src/Skynet.Protocol/Packets/P06CreateSession.cs
@@ -17,14 +17,14 @@ namespace Skynet.Protocol.Packets
         protected override void ReadPacketInternal(PacketBuffer buffer, PacketRole role)
         {
             AccountName = buffer.ReadShortString();
-            KeyHash = buffer.ReadRawByteArray(32).ToArray();
+            KeyHash = buffer.ReadByteArray(32);
             FcmRegistrationToken = buffer.ReadMediumString();
         }
 
         protected override void WritePacketInternal(PacketBuffer buffer, PacketRole role)
         {
             buffer.WriteShortString(AccountName);
-            buffer.WriteRawByteArray(KeyHash);
+            buffer.WriteByteArray(KeyHash);
             buffer.WriteMediumString(FcmRegistrationToken);
         }
 

--- a/src/Skynet.Protocol/Packets/P07CreateSessionResponse.cs
+++ b/src/Skynet.Protocol/Packets/P07CreateSessionResponse.cs
@@ -22,7 +22,7 @@ namespace Skynet.Protocol.Packets
             StatusCode = (CreateSessionStatus)buffer.ReadByte();
             AccountId = buffer.ReadInt64();
             SessionId = buffer.ReadInt64();
-            SessionToken = buffer.ReadRawByteArray(32).ToArray();
+            SessionToken = buffer.ReadByteArray(32);
             WebToken = buffer.ReadMediumString();
         }
 
@@ -31,7 +31,7 @@ namespace Skynet.Protocol.Packets
             buffer.WriteByte((byte)StatusCode);
             buffer.WriteInt64(AccountId);
             buffer.WriteInt64(SessionId);
-            buffer.WriteRawByteArray(SessionToken);
+            buffer.WriteByteArray(SessionToken);
             buffer.WriteMediumString(WebToken);
         }
 

--- a/src/Skynet.Protocol/Packets/P08RestoreSession.cs
+++ b/src/Skynet.Protocol/Packets/P08RestoreSession.cs
@@ -18,7 +18,7 @@ namespace Skynet.Protocol.Packets
         protected override void ReadPacketInternal(PacketBuffer buffer, PacketRole role)
         {
             SessionId = buffer.ReadInt64();
-            SessionToken = buffer.ReadRawByteArray(32).ToArray();
+            SessionToken = buffer.ReadByteArray(32);
             ushort length = buffer.ReadUInt16();
             for (int i = 0; i < length; i++)
             {
@@ -29,7 +29,7 @@ namespace Skynet.Protocol.Packets
         protected override void WritePacketInternal(PacketBuffer buffer, PacketRole role)
         {
             buffer.WriteInt64(SessionId);
-            buffer.WriteRawByteArray(SessionToken);
+            buffer.WriteByteArray(SessionToken);
             buffer.WriteUInt16((ushort)Channels.Count);
             foreach (long channelId in Channels)
             {

--- a/src/Skynet.Protocol/Packets/P15PasswordUpdate.cs
+++ b/src/Skynet.Protocol/Packets/P15PasswordUpdate.cs
@@ -18,15 +18,15 @@ namespace Skynet.Protocol.Packets
 
         protected override void ReadMessage(PacketBuffer buffer)
         {
-            PreviousKeyHash = buffer.ReadRawByteArray(32).ToArray();
-            KeyHash = buffer.ReadRawByteArray(32).ToArray();
-            KeyHistory = buffer.ReadMediumByteArray().ToArray();
+            PreviousKeyHash = buffer.ReadByteArray(32);
+            KeyHash = buffer.ReadByteArray(32);
+            KeyHistory = buffer.ReadMediumByteArray();
         }
 
         protected override void WriteMessage(PacketBuffer buffer)
         {
-            buffer.WriteRawByteArray(PreviousKeyHash);
-            buffer.WriteRawByteArray(KeyHash);
+            buffer.WriteByteArray(PreviousKeyHash);
+            buffer.WriteByteArray(KeyHash);
             buffer.WriteMediumByteArray(KeyHistory);
         }
     }

--- a/src/Skynet.Protocol/Packets/P17PrivateKeys.cs
+++ b/src/Skynet.Protocol/Packets/P17PrivateKeys.cs
@@ -21,9 +21,9 @@ namespace Skynet.Protocol.Packets
         protected override void ReadMessage(PacketBuffer buffer)
         {
             SignatureKeyFormat = (KeyFormat)buffer.ReadByte();
-            SignatureKey = buffer.ReadMediumByteArray().ToArray();
+            SignatureKey = buffer.ReadMediumByteArray();
             DerivationKeyFormat = (KeyFormat)buffer.ReadByte();
-            DerivationKey = buffer.ReadMediumByteArray().ToArray();
+            DerivationKey = buffer.ReadMediumByteArray();
         }
 
         protected override void WriteMessage(PacketBuffer buffer)

--- a/src/Skynet.Protocol/Packets/P17PrivateKeys.cs
+++ b/src/Skynet.Protocol/Packets/P17PrivateKeys.cs
@@ -33,5 +33,13 @@ namespace Skynet.Protocol.Packets
             buffer.WriteByte((byte)DerivationKeyFormat);
             buffer.WriteMediumByteArray(DerivationKey);
         }
+
+        protected override void DisposeMessage()
+        {
+            base.DisposeMessage();
+
+            Array.Clear(SignatureKey, 0, SignatureKey.Length);
+            Array.Clear(DerivationKey, 0, DerivationKey.Length);
+        }
     }
 }

--- a/src/Skynet.Protocol/Packets/P18PublicKeys.cs
+++ b/src/Skynet.Protocol/Packets/P18PublicKeys.cs
@@ -21,9 +21,9 @@ namespace Skynet.Protocol.Packets
         protected override void ReadMessage(PacketBuffer buffer)
         {
             SignatureKeyFormat = (KeyFormat)buffer.ReadByte();
-            SignatureKey = buffer.ReadMediumByteArray().ToArray();
+            SignatureKey = buffer.ReadMediumByteArray();
             DerivationKeyFormat = (KeyFormat)buffer.ReadByte();
-            DerivationKey = buffer.ReadMediumByteArray().ToArray();
+            DerivationKey = buffer.ReadMediumByteArray();
         }
 
         protected override void WriteMessage(PacketBuffer buffer)

--- a/src/Skynet.Protocol/Packets/P1AVerifiedKeys.cs
+++ b/src/Skynet.Protocol/Packets/P1AVerifiedKeys.cs
@@ -16,12 +16,12 @@ namespace Skynet.Protocol.Packets
 
         protected override void ReadMessage(PacketBuffer buffer)
         {
-            Sha256 = buffer.ReadRawByteArray(32).ToArray();
+            Sha256 = buffer.ReadByteArray(32);
         }
 
         protected override void WriteMessage(PacketBuffer buffer)
         {
-            buffer.WriteRawByteArray(Sha256);
+            buffer.WriteByteArray(Sha256);
         }
     }
 }

--- a/src/Skynet.Protocol/Packets/P1DGroupChannelKeyNotify.cs
+++ b/src/Skynet.Protocol/Packets/P1DGroupChannelKeyNotify.cs
@@ -30,5 +30,13 @@ namespace Skynet.Protocol.Packets
             buffer.WriteByteArray(NewKey);
             buffer.WriteByteArray(HistoryKey);
         }
+
+        protected override void DisposeMessage()
+        {
+            base.DisposeMessage();
+
+            Array.Clear(NewKey, 0, NewKey.Length);
+            Array.Clear(HistoryKey, 0, HistoryKey.Length);
+        }
     }
 }

--- a/src/Skynet.Protocol/Packets/P1DGroupChannelKeyNotify.cs
+++ b/src/Skynet.Protocol/Packets/P1DGroupChannelKeyNotify.cs
@@ -20,15 +20,15 @@ namespace Skynet.Protocol.Packets
         protected override void ReadMessage(PacketBuffer buffer)
         {
             ChannelId = buffer.ReadInt64();
-            NewKey = buffer.ReadRawByteArray(64).ToArray();
-            HistoryKey = buffer.ReadRawByteArray(64).ToArray();
+            NewKey = buffer.ReadByteArray(64);
+            HistoryKey = buffer.ReadByteArray(64);
         }
 
         protected override void WriteMessage(PacketBuffer buffer)
         {
             buffer.WriteInt64(ChannelId);
-            buffer.WriteRawByteArray(NewKey);
-            buffer.WriteRawByteArray(HistoryKey);
+            buffer.WriteByteArray(NewKey);
+            buffer.WriteByteArray(HistoryKey);
         }
     }
 }

--- a/src/Skynet.Protocol/Packets/P1EGroupChannelUpdate.cs
+++ b/src/Skynet.Protocol/Packets/P1EGroupChannelUpdate.cs
@@ -24,7 +24,7 @@ namespace Skynet.Protocol.Packets
             {
                 Members.Add((buffer.ReadInt64(), (GroupMemberFlags)buffer.ReadByte()));
             }
-            KeyHistory = buffer.ReadMediumByteArray().ToArray();
+            KeyHistory = buffer.ReadMediumByteArray();
         }
 
         protected override void WriteMessage(PacketBuffer buffer)

--- a/src/Skynet.Protocol/Skynet.Protocol.csproj
+++ b/src/Skynet.Protocol/Skynet.Protocol.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <Copyright>© 2018-2020 Daniel Lerch, Twometer and Beniox</Copyright>
-    <Version>5.2.0</Version>
+    <Version>5.2.1</Version>
     <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
     <Authors>Daniel Lerch, Twometer, Beniox</Authors>
     <RepositoryUrl>https://github.com/skynet-im/skynet-dotnet</RepositoryUrl>
@@ -14,7 +14,7 @@ It contains packet abstraction, attributes and implementation as well as channel
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Skynet.Core" Version="5.2.0" />
+    <PackageReference Include="Skynet.Core" Version="5.2.1" />
     <ProjectReference Include="..\Skynet.Core\Skynet.Core.csproj" />
   </ItemGroup>
 

--- a/src/Skynet.Protocol/Skynet.Protocol.csproj
+++ b/src/Skynet.Protocol/Skynet.Protocol.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Copyright>© 2018-2020 Daniel Lerch, Twometer and Beniox</Copyright>
     <Version>5.2.1</Version>
     <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/tests/Skynet.Core.Tests/MemoryAssert.cs
+++ b/tests/Skynet.Core.Tests/MemoryAssert.cs
@@ -8,13 +8,31 @@ namespace Skynet.Tests
         public static void AreEqual<T>(ReadOnlySpan<T> expected, ReadOnlySpan<T> actual) where T : IEquatable<T>
         {
             if (!expected.SequenceEqual(actual))
-                Assert.Fail("MemoryAssert.AreEqual failed.");
+                throw new AssertFailedException("MemoryAssert.AreEqual failed.");
         }
 
         public static void AreEqual<T>(ReadOnlyMemory<T> expected, ReadOnlyMemory<T> actual) where T : IEquatable<T>
         {
             if (!expected.Span.SequenceEqual(actual.Span))
-                Assert.Fail("MemoryAssert.AreEqual failed.");
+                throw new AssertFailedException("MemoryAssert.AreEqual failed.");
+        }
+
+        public static void AreEqual<T>(T[] expected, ReadOnlySpan<T> actual) where T : IEquatable<T>
+        {
+            if (!expected.AsSpan().SequenceEqual(actual))
+                throw new AssertFailedException("MemoryAssert.AreEqual failed.");
+        }
+
+        public static void AreEqual<T>(T[] expected, ReadOnlyMemory<T> actual) where T : IEquatable<T>
+        {
+            if (!expected.AsSpan().SequenceEqual(actual.Span))
+                throw new AssertFailedException("MemoryAssert.AreEqual failed.");
+        }
+
+        public static void AreEqual<T>(T[] expected, T[] actual) where T : IEquatable<T>
+        {
+            if (!expected.AsSpan().SequenceEqual(actual))
+                throw new AssertFailedException("MemoryAssert.AreEqual failed.");
         }
     }
 }

--- a/tests/Skynet.Core.Tests/Network/PacketBufferTests.cs
+++ b/tests/Skynet.Core.Tests/Network/PacketBufferTests.cs
@@ -26,8 +26,8 @@ namespace Skynet.Tests.Network
         {
             var buffer = new PacketBuffer(capacity: 4);
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => buffer.Position = -1);
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => buffer.Position = 5);
-            buffer.Position = 4;
+            buffer.Position = 500;
+            Assert.IsTrue(buffer.Capacity >= 500);
         }
 
         [TestMethod]

--- a/tests/Skynet.Core.Tests/Network/PacketBufferTests.cs
+++ b/tests/Skynet.Core.Tests/Network/PacketBufferTests.cs
@@ -18,7 +18,7 @@ namespace Skynet.Tests.Network
             buffer.ReadBoolean();
             Assert.ThrowsException<EndOfStreamException>(() => buffer.ReadInt32());
             Assert.ThrowsException<EndOfStreamException>(() => buffer.ReadMediumByteArray());
-            Assert.ThrowsException<EndOfStreamException>(() => buffer.ReadRawByteArray(13));
+            Assert.ThrowsException<EndOfStreamException>(() => buffer.ReadByteArray(13));
         }
 
         [TestMethod]
@@ -28,6 +28,27 @@ namespace Skynet.Tests.Network
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => buffer.Position = -1);
             buffer.Position = 500;
             Assert.IsTrue(buffer.Capacity >= 500);
+        }
+
+        [TestMethod]
+        public void TestWriteSizeCheck()
+        {
+            byte[] empty = Array.Empty<byte>();
+            byte[] random1 = new byte[128];
+            byte[] random2 = new byte[3072];
+            byte[] random3 = new byte[262144];
+            Random gen = new Random();
+            gen.NextBytes(random1);
+            gen.NextBytes(random2);
+            gen.NextBytes(random3);
+
+            var write = new PacketBuffer();
+            write.WriteByteArray(empty);
+            write.WriteByteArray(random2);
+            write.WriteShortByteArray(random1);
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => write.WriteShortByteArray(random2));
+            write.WriteMediumByteArray(random2);
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => write.WriteMediumByteArray(random3));
         }
 
         [TestMethod]
@@ -48,13 +69,11 @@ namespace Skynet.Tests.Network
             Assert.ThrowsException<InvalidOperationException>(() => read.WriteInt64(0x1a41a174a64c91aa));
             Assert.ThrowsException<InvalidOperationException>(() => read.WriteDateTime(default));
             Assert.ThrowsException<InvalidOperationException>(() => read.WriteUuid(default));
-            Assert.ThrowsException<InvalidOperationException>(() => read.WriteRawByteArray(bytes));
+            Assert.ThrowsException<InvalidOperationException>(() => read.WriteByteArray(bytes));
             Assert.ThrowsException<InvalidOperationException>(() => read.WriteShortByteArray(bytes));
             Assert.ThrowsException<InvalidOperationException>(() => read.WriteMediumByteArray(bytes));
-            Assert.ThrowsException<InvalidOperationException>(() => read.WriteLongByteArray(bytes));
             Assert.ThrowsException<InvalidOperationException>(() => read.WriteShortString(text));
             Assert.ThrowsException<InvalidOperationException>(() => read.WriteMediumString(text));
-            Assert.ThrowsException<InvalidOperationException>(() => read.WriteLongString(text));
         }
 
         [TestMethod]
@@ -119,20 +138,24 @@ namespace Skynet.Tests.Network
             gen.NextBytes(random3);
 
             var write = new PacketBuffer();
-            write.WriteRawByteArray(empty);
-            write.WriteRawByteArray(random2);
+            write.WriteByteArray(empty);
+            write.WriteByteArray(random1);
             write.WriteShortByteArray(random1);
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => write.WriteShortByteArray(random2));
             write.WriteMediumByteArray(random2);
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => write.WriteMediumByteArray(random3));
-            write.WriteLongByteArray(random3);
+            write.WriteMediumByteArray(random2);
+            write.WriteByteArray(random3);
 
             var read = new PacketBuffer(write.GetBuffer());
-            MemoryAssert.AreEqual(empty, read.ReadRawByteArray(0));
-            MemoryAssert.AreEqual(random2, read.ReadRawByteArray(random2.Length));
+            MemoryAssert.AreEqual(empty, read.ReadByteArray(0));
+            MemoryAssert.AreEqual(random1, read.ReadByteArray(random1.Length));
             MemoryAssert.AreEqual(random1, read.ReadShortByteArray());
             MemoryAssert.AreEqual(random2, read.ReadMediumByteArray());
-            MemoryAssert.AreEqual(random3, read.ReadLongByteArray());
+            PoolableMemory memory1 = read.ReadMediumPooledArray();
+            PoolableMemory memory2 = read.ReadPooledArray(random3.Length);
+            MemoryAssert.AreEqual(random2, memory1.Memory);
+            MemoryAssert.AreEqual(random3, memory2.Memory);
+            memory1.Return(false);
+            memory2.Return(false);
         }
 
         [TestMethod]
@@ -161,12 +184,10 @@ Dignissim convallis aenean et tortor at risus viverra adipiscing at.";
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => write.WriteShortString(string2));
             write.WriteMediumString(string2);
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => write.WriteMediumString(string3));
-            write.WriteLongString(string3);
 
             var read = new PacketBuffer(write.GetBuffer());
             Assert.AreEqual(string1, read.ReadShortString());
             Assert.AreEqual(string2, read.ReadMediumString());
-            Assert.AreEqual(string3, read.ReadLongString());
         }
     }
 }

--- a/tests/Skynet.Protocol.Tests/ChannelMessageTests.cs
+++ b/tests/Skynet.Protocol.Tests/ChannelMessageTests.cs
@@ -1,0 +1,76 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Skynet.Model;
+using Skynet.Network;
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+
+namespace Skynet.Protocol.Tests
+{
+    [TestClass]
+    public class ChannelMessageTests
+    {
+        private const string text = "Hello World!";
+
+        [TestMethod]
+        public void TestUnencrypted()
+        {
+            using var message = new FakeMessage { Text = text, MessageFlags = MessageFlags.Unencrypted };
+            using var buffer = new PacketBuffer();
+
+            message.WritePacket(buffer, PacketRole.Client);
+            
+            buffer.Position = 0;
+
+            using var received = new FakeMessage();
+            received.ReadPacket(buffer, PacketRole.Server);
+
+            Assert.AreEqual(text, received.Text);
+        }
+
+        [TestMethod]
+        public void TestEncrypted()
+        {
+            using var message = new FakeMessage { Text = text };
+            Span<byte> key = stackalloc byte[64];
+            RandomNumberGenerator.Fill(key);
+
+            using var buffer = new PacketBuffer();
+
+            message.Encrypt(key);
+            message.WritePacket(buffer, PacketRole.Client);
+
+            buffer.Position = 0;
+
+            using var received = new FakeMessage();
+            received.ReadPacket(buffer, PacketRole.Server);
+            received.Decrypt(key);
+
+            Assert.AreEqual(text, received.Text);
+        }
+
+        private class FakeMessage : ChannelMessage
+        {
+            public FakeMessage()
+            {
+                Id = 0x7f;
+                Policies = PacketPolicies.Duplex;
+                AllowedFlags = MessageFlags.Unencrypted;
+            }
+
+            public string Text { get; set; }
+
+            public override Packet Create() => new FakeMessage();
+
+            protected override void ReadMessage(PacketBuffer buffer)
+            {
+                Text = buffer.ReadMediumString();
+            }
+
+            protected override void WriteMessage(PacketBuffer buffer)
+            {
+                buffer.WriteMediumString(Text);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Array clearing
This pull request resolves #2. Arrays containing sensitive data are now cleared. Data that is only protected by transport security is not considered as sensitive.

In order to implement clearing effectively, `PacketBuffer` and `ChannelMessage` now implement `IDisposable`.

### Array pooling
This API change made it possible to implement array pooling easily. The new `PoolableMemory` struct is used to simplify handling pooled arrays.

Allocating a new array of 10,000 bytes takes almost ten times longer than taking one from an `ArrayPool<T>`. With this change we can avoid such allocations on the server while handling large channel messages. Unfortunately EF Core is not optimized for such workloads but at least the packets are as efficient as possible.