### PR TITLE
Improve ChannelMessage API

### DIFF
--- a/src/Skynet.Core/Skynet.Core.csproj
+++ b/src/Skynet.Core/Skynet.Core.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Copyright>© 2017-2020 Daniel Lerch</Copyright>
-    <Version>5.2.1</Version>
+    <Version>5.2.2</Version>
     <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
     <Authors>Daniel Lerch</Authors>
     <RepositoryUrl>https://github.com/skynet-im/skynet-dotnet</RepositoryUrl>

--- a/src/Skynet.Protocol/ChannelMessageFile.cs
+++ b/src/Skynet.Protocol/ChannelMessageFile.cs
@@ -55,7 +55,7 @@ namespace Skynet.Protocol
             {
                 buffer.WriteShortString(ContentType);
                 buffer.WriteInt64(Length);
-                buffer.WriteByteArray(Key);
+                buffer.WriteByteArray(Key, 32);
             }
         }
 

--- a/src/Skynet.Protocol/Packets/P02CreateAccount.cs
+++ b/src/Skynet.Protocol/Packets/P02CreateAccount.cs
@@ -22,7 +22,7 @@ namespace Skynet.Protocol.Packets
         protected override void WritePacketInternal(PacketBuffer buffer, PacketRole role)
         {
             buffer.WriteShortString(AccountName);
-            buffer.WriteByteArray(KeyHash);
+            buffer.WriteByteArray(KeyHash, 32);
         }
 
         public override string ToString()

--- a/src/Skynet.Protocol/Packets/P04DeleteAccount.cs
+++ b/src/Skynet.Protocol/Packets/P04DeleteAccount.cs
@@ -19,7 +19,7 @@ namespace Skynet.Protocol.Packets
 
         protected override void WritePacketInternal(PacketBuffer buffer, PacketRole role)
         {
-            buffer.WriteByteArray(KeyHash);
+            buffer.WriteByteArray(KeyHash, 32);
         }
     }
 }

--- a/src/Skynet.Protocol/Packets/P06CreateSession.cs
+++ b/src/Skynet.Protocol/Packets/P06CreateSession.cs
@@ -24,7 +24,7 @@ namespace Skynet.Protocol.Packets
         protected override void WritePacketInternal(PacketBuffer buffer, PacketRole role)
         {
             buffer.WriteShortString(AccountName);
-            buffer.WriteByteArray(KeyHash);
+            buffer.WriteByteArray(KeyHash, 32);
             buffer.WriteMediumString(FcmRegistrationToken);
         }
 

--- a/src/Skynet.Protocol/Packets/P07CreateSessionResponse.cs
+++ b/src/Skynet.Protocol/Packets/P07CreateSessionResponse.cs
@@ -31,7 +31,7 @@ namespace Skynet.Protocol.Packets
             buffer.WriteByte((byte)StatusCode);
             buffer.WriteInt64(AccountId);
             buffer.WriteInt64(SessionId);
-            buffer.WriteByteArray(SessionToken);
+            buffer.WriteByteArray(SessionToken, 32);
             buffer.WriteMediumString(WebToken);
         }
 

--- a/src/Skynet.Protocol/Packets/P08RestoreSession.cs
+++ b/src/Skynet.Protocol/Packets/P08RestoreSession.cs
@@ -29,7 +29,7 @@ namespace Skynet.Protocol.Packets
         protected override void WritePacketInternal(PacketBuffer buffer, PacketRole role)
         {
             buffer.WriteInt64(SessionId);
-            buffer.WriteByteArray(SessionToken);
+            buffer.WriteByteArray(SessionToken, 32);
             buffer.WriteUInt16((ushort)Channels.Count);
             foreach (long channelId in Channels)
             {

--- a/src/Skynet.Protocol/Packets/P15PasswordUpdate.cs
+++ b/src/Skynet.Protocol/Packets/P15PasswordUpdate.cs
@@ -25,8 +25,8 @@ namespace Skynet.Protocol.Packets
 
         protected override void WriteMessage(PacketBuffer buffer)
         {
-            buffer.WriteByteArray(PreviousKeyHash);
-            buffer.WriteByteArray(KeyHash);
+            buffer.WriteByteArray(PreviousKeyHash, 32);
+            buffer.WriteByteArray(KeyHash, 32);
             buffer.WriteMediumByteArray(KeyHistory);
         }
     }

--- a/src/Skynet.Protocol/Packets/P1AVerifiedKeys.cs
+++ b/src/Skynet.Protocol/Packets/P1AVerifiedKeys.cs
@@ -21,7 +21,7 @@ namespace Skynet.Protocol.Packets
 
         protected override void WriteMessage(PacketBuffer buffer)
         {
-            buffer.WriteByteArray(Sha256);
+            buffer.WriteByteArray(Sha256, 32);
         }
     }
 }

--- a/src/Skynet.Protocol/Packets/P1DGroupChannelKeyNotify.cs
+++ b/src/Skynet.Protocol/Packets/P1DGroupChannelKeyNotify.cs
@@ -27,8 +27,8 @@ namespace Skynet.Protocol.Packets
         protected override void WriteMessage(PacketBuffer buffer)
         {
             buffer.WriteInt64(ChannelId);
-            buffer.WriteByteArray(NewKey);
-            buffer.WriteByteArray(HistoryKey);
+            buffer.WriteByteArray(NewKey, 64);
+            buffer.WriteByteArray(HistoryKey, 64);
         }
 
         protected override void DisposeMessage()

--- a/src/Skynet.Protocol/Skynet.Protocol.csproj
+++ b/src/Skynet.Protocol/Skynet.Protocol.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Copyright>© 2018-2020 Daniel Lerch, Twometer and Beniox</Copyright>
-    <Version>5.2.1</Version>
+    <Version>5.2.2</Version>
     <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
     <Authors>Daniel Lerch, Twometer, Beniox</Authors>
     <RepositoryUrl>https://github.com/skynet-im/skynet-dotnet</RepositoryUrl>
@@ -15,7 +15,7 @@ It contains packet abstraction, attributes and implementation as well as channel
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Skynet.Core" Version="5.2.1" />
+    <PackageReference Include="Skynet.Core" Version="5.2.2" />
     <ProjectReference Include="..\Skynet.Core\Skynet.Core.csproj" />
   </ItemGroup>
 

--- a/tests/Skynet.Protocol.Tests/ChannelMessageTests.cs
+++ b/tests/Skynet.Protocol.Tests/ChannelMessageTests.cs
@@ -49,6 +49,26 @@ namespace Skynet.Protocol.Tests
             Assert.AreEqual(text, received.Text);
         }
 
+
+        [TestMethod]
+        public void TestPacketContentUnencrypted()
+        {
+            using var message = new FakeMessage { Text = text, MessageFlags = MessageFlags.Unencrypted };
+
+            byte[] content = message.PacketContent;
+            Assert.IsNotNull(content);
+            using var buffer = new PacketBuffer(content);
+            Assert.AreEqual(text, buffer.ReadMediumString());
+        }
+
+        [TestMethod]
+        public void TestPacketContentEncrypted()
+        {
+            using var message = new FakeMessage { Text = text };
+
+            Assert.IsNull(message.PacketContent);
+        }
+
         private class FakeMessage : ChannelMessage
         {
             public FakeMessage()


### PR DESCRIPTION
This pull request includes several enhancements of the public API:
- `ChannelMessage` is now abstract
- Access `ChannelMessage.PacketContent` at any time
- Validation for `ChannelMessage.MessageFlags`
- `PacketBuffer` now supports fixed length arrays