### PR TITLE
Enable C# nullable reference types

### DIFF
--- a/src/Skynet.Protocol/ChannelMessage.cs
+++ b/src/Skynet.Protocol/ChannelMessage.cs
@@ -200,12 +200,13 @@ namespace Skynet.Protocol
 
         private PoolableMemory WriteContent()
         {
-            if (File == null) throw new InvalidOperationException("You cannot write a message with MessageFlags.MediaMessage if File is null.");
+            if (messageFlags.HasFlag(MessageFlags.MediaMessage) && File == null)
+                throw new InvalidOperationException("You cannot write a message with MessageFlags.MediaMessage if File is null.");
 
             PacketBuffer contentBuffer = new PacketBuffer();
             WriteMessage(contentBuffer);
             if (messageFlags.HasFlag(MessageFlags.MediaMessage))
-                File.Write(contentBuffer, messageFlags.HasFlag(MessageFlags.ExternalFile));
+                File!.Write(contentBuffer, messageFlags.HasFlag(MessageFlags.ExternalFile));
             return contentBuffer.GetBufferAndDispose();
         }
 

--- a/src/Skynet.Protocol/ChannelMessageFile.cs
+++ b/src/Skynet.Protocol/ChannelMessageFile.cs
@@ -8,7 +8,7 @@ namespace Skynet.Protocol
     {
         private bool disposed;
         private PoolableMemory thumbnailData;
-        private byte[] key;
+        private byte[]? key;
 
         public string Name { get; set; }
         public DateTime CreationTime { get; set; }
@@ -19,9 +19,9 @@ namespace Skynet.Protocol
             get { if (disposed) throw new ObjectDisposedException(nameof(ChannelMessageFile)); return thumbnailData; }
             set { if (disposed) throw new ObjectDisposedException(nameof(ChannelMessageFile)); thumbnailData = value; }
         }
-        public string ContentType { get; set; }
+        public string? ContentType { get; set; }
         public long Length { get; set; }
-        public byte[] Key
+        public byte[]? Key
         {
             get { if (disposed) throw new ObjectDisposedException(nameof(ChannelMessageFile)); return key; }
             set { if (disposed) throw new ObjectDisposedException(nameof(ChannelMessageFile)); key = value; }
@@ -33,13 +33,13 @@ namespace Skynet.Protocol
             CreationTime = buffer.ReadDateTime();
             LastWriteTime = buffer.ReadDateTime();
             ThumbnailContentType = buffer.ReadShortString();
-            ThumbnailData = buffer.ReadMediumPooledArray();
+            thumbnailData = buffer.ReadMediumPooledArray();
 
             if (external)
             {
                 ContentType = buffer.ReadShortString();
                 Length = buffer.ReadInt64();
-                Key = buffer.ReadByteArray(32);
+                key = buffer.ReadByteArray(32);
             }
         }
 
@@ -63,8 +63,8 @@ namespace Skynet.Protocol
         {
             if (!disposed)
             {
-                ThumbnailData.Return(true);
-                Array.Clear(Key, 0, Key.Length);
+                thumbnailData.Return(true);
+                key.AsSpan().Clear();
 
                 disposed = true;
             }

--- a/src/Skynet.Protocol/Packets/P00ConnectionHandshake.cs
+++ b/src/Skynet.Protocol/Packets/P00ConnectionHandshake.cs
@@ -9,7 +9,7 @@ namespace Skynet.Protocol.Packets
     public sealed class P00ConnectionHandshake : Packet
     {
         public int ProtocolVersion { get; set; }
-        public string ApplicationIdentifier { get; set; }
+        public string? ApplicationIdentifier { get; set; }
         public int VersionCode { get; set; }
 
         public override Packet Create() => new P00ConnectionHandshake().Init(this);

--- a/src/Skynet.Protocol/Packets/P01ConnectionResponse.cs
+++ b/src/Skynet.Protocol/Packets/P01ConnectionResponse.cs
@@ -11,7 +11,7 @@ namespace Skynet.Protocol.Packets
     {
         public ConnectionState ConnectionState { get; set; }
         public int LatestVersionCode { get; set; }
-        public string LatestVersion { get; set; }
+        public string? LatestVersion { get; set; }
 
         public override Packet Create() => new P01ConnectionResponse().Init(this);
 

--- a/src/Skynet.Protocol/Packets/P02CreateAccount.cs
+++ b/src/Skynet.Protocol/Packets/P02CreateAccount.cs
@@ -8,8 +8,8 @@ namespace Skynet.Protocol.Packets
     [Packet(0x02, PacketPolicies.ClientToServer | PacketPolicies.Unauthenticated)]
     public sealed class P02CreateAccount : Packet
     {
-        public string AccountName { get; set; }
-        public byte[] KeyHash { get; set; }
+        public string? AccountName { get; set; }
+        public byte[]? KeyHash { get; set; }
 
         public override Packet Create() => new P02CreateAccount().Init(this);
 

--- a/src/Skynet.Protocol/Packets/P04DeleteAccount.cs
+++ b/src/Skynet.Protocol/Packets/P04DeleteAccount.cs
@@ -8,7 +8,7 @@ namespace Skynet.Protocol.Packets
     [Packet(0x04, PacketPolicies.ClientToServer)]
     public sealed class P04DeleteAccount : Packet
     {
-        public byte[] KeyHash { get; set; }
+        public byte[]? KeyHash { get; set; }
 
         public override Packet Create() => new P04DeleteAccount().Init(this);
 

--- a/src/Skynet.Protocol/Packets/P06CreateSession.cs
+++ b/src/Skynet.Protocol/Packets/P06CreateSession.cs
@@ -8,9 +8,9 @@ namespace Skynet.Protocol.Packets
     [Packet(0x06, PacketPolicies.ClientToServer | PacketPolicies.Unauthenticated)]
     public sealed class P06CreateSession : Packet
     {
-        public string AccountName { get; set; }
-        public byte[] KeyHash { get; set; }
-        public string FcmRegistrationToken { get; set; }
+        public string? AccountName { get; set; }
+        public byte[]? KeyHash { get; set; }
+        public string? FcmRegistrationToken { get; set; }
 
         public override Packet Create() => new P06CreateSession().Init(this);
 

--- a/src/Skynet.Protocol/Packets/P07CreateSessionResponse.cs
+++ b/src/Skynet.Protocol/Packets/P07CreateSessionResponse.cs
@@ -12,8 +12,8 @@ namespace Skynet.Protocol.Packets
         public CreateSessionStatus StatusCode { get; set; }
         public long AccountId { get; set; }
         public long SessionId { get; set; }
-        public byte[] SessionToken { get; set; }
-        public string WebToken { get; set; }
+        public byte[]? SessionToken { get; set; }
+        public string? WebToken { get; set; }
 
         public override Packet Create() => new P07CreateSessionResponse().Init(this);
 

--- a/src/Skynet.Protocol/Packets/P08RestoreSession.cs
+++ b/src/Skynet.Protocol/Packets/P08RestoreSession.cs
@@ -9,7 +9,7 @@ namespace Skynet.Protocol.Packets
     public sealed class P08RestoreSession : Packet
     {
         public long SessionId { get; set; }
-        public byte[] SessionToken { get; set; }
+        public byte[]? SessionToken { get; set; }
         public long LastMessageId { get; set; }
         public List<long> Channels { get; set; } = new List<long>();
 

--- a/src/Skynet.Protocol/Packets/P08RestoreSession.cs
+++ b/src/Skynet.Protocol/Packets/P08RestoreSession.cs
@@ -19,6 +19,8 @@ namespace Skynet.Protocol.Packets
         {
             SessionId = buffer.ReadInt64();
             SessionToken = buffer.ReadByteArray(32);
+            LastMessageId = buffer.ReadInt64();
+
             ushort length = buffer.ReadUInt16();
             for (int i = 0; i < length; i++)
             {
@@ -30,6 +32,8 @@ namespace Skynet.Protocol.Packets
         {
             buffer.WriteInt64(SessionId);
             buffer.WriteByteArray(SessionToken, 32);
+            buffer.WriteInt64(LastMessageId);
+
             buffer.WriteUInt16((ushort)Channels.Count);
             foreach (long channelId in Channels)
             {

--- a/src/Skynet.Protocol/Packets/P13QueueMailAddressChange.cs
+++ b/src/Skynet.Protocol/Packets/P13QueueMailAddressChange.cs
@@ -10,7 +10,7 @@ namespace Skynet.Protocol.Packets
     [MessageFlags(MessageFlags.Loopback | MessageFlags.Unencrypted)]
     public sealed class P13QueueMailAddressChange : ChannelMessage
     {
-        public string NewMailAddress { get; set; }
+        public string? NewMailAddress { get; set; }
 
         public override Packet Create() => new P13QueueMailAddressChange().Init(this);
 

--- a/src/Skynet.Protocol/Packets/P14MailAddress.cs
+++ b/src/Skynet.Protocol/Packets/P14MailAddress.cs
@@ -10,7 +10,7 @@ namespace Skynet.Protocol.Packets
     [MessageFlags(MessageFlags.Unencrypted)]
     public sealed class P14MailAddress : ChannelMessage
     {
-        public string MailAddress { get; set; }
+        public string? MailAddress { get; set; }
 
         public override Packet Create() => new P14MailAddress().Init(this);
 

--- a/src/Skynet.Protocol/Packets/P15PasswordUpdate.cs
+++ b/src/Skynet.Protocol/Packets/P15PasswordUpdate.cs
@@ -10,9 +10,9 @@ namespace Skynet.Protocol.Packets
     [MessageFlags(MessageFlags.Loopback | MessageFlags.Unencrypted)]
     public sealed class P15PasswordUpdate : ChannelMessage
     {
-        public byte[] PreviousKeyHash { get; set; }
-        public byte[] KeyHash { get; set; }
-        public byte[] KeyHistory { get; set; }
+        public byte[]? PreviousKeyHash { get; set; }
+        public byte[]? KeyHash { get; set; }
+        public byte[]? KeyHistory { get; set; }
 
         public override Packet Create() => new P15PasswordUpdate().Init(this);
 

--- a/src/Skynet.Protocol/Packets/P17PrivateKeys.cs
+++ b/src/Skynet.Protocol/Packets/P17PrivateKeys.cs
@@ -12,9 +12,9 @@ namespace Skynet.Protocol.Packets
     public sealed class P17PrivateKeys : ChannelMessage
     {
         public KeyFormat SignatureKeyFormat { get; set; }
-        public byte[] SignatureKey { get; set; }
+        public byte[]? SignatureKey { get; set; }
         public KeyFormat DerivationKeyFormat { get; set; }
-        public byte[] DerivationKey { get; set; }
+        public byte[]? DerivationKey { get; set; }
 
         public override Packet Create() => new P17PrivateKeys().Init(this);
 
@@ -34,12 +34,10 @@ namespace Skynet.Protocol.Packets
             buffer.WriteMediumByteArray(DerivationKey);
         }
 
-        protected override void DisposeMessage()
+        protected override void DisposeContents()
         {
-            base.DisposeMessage();
-
-            Array.Clear(SignatureKey, 0, SignatureKey.Length);
-            Array.Clear(DerivationKey, 0, DerivationKey.Length);
+            SignatureKey.AsSpan().Clear();
+            DerivationKey.AsSpan().Clear();
         }
     }
 }

--- a/src/Skynet.Protocol/Packets/P18PublicKeys.cs
+++ b/src/Skynet.Protocol/Packets/P18PublicKeys.cs
@@ -12,9 +12,9 @@ namespace Skynet.Protocol.Packets
     public sealed class P18PublicKeys : ChannelMessage
     {
         public KeyFormat SignatureKeyFormat { get; set; }
-        public byte[] SignatureKey { get; set; }
+        public byte[]? SignatureKey { get; set; }
         public KeyFormat DerivationKeyFormat { get; set; }
-        public byte[] DerivationKey { get; set; }
+        public byte[]? DerivationKey { get; set; }
 
         public override Packet Create() => new P18PublicKeys().Init(this);
 

--- a/src/Skynet.Protocol/Packets/P1AVerifiedKeys.cs
+++ b/src/Skynet.Protocol/Packets/P1AVerifiedKeys.cs
@@ -10,7 +10,7 @@ namespace Skynet.Protocol.Packets
     [MessageFlags(MessageFlags.Loopback)]
     public sealed class P1AVerifiedKeys : ChannelMessage
     {
-        public byte[] Sha256 { get; set; }
+        public byte[]? Sha256 { get; set; }
 
         public override Packet Create() => new P1AVerifiedKeys().Init(this);
 

--- a/src/Skynet.Protocol/Packets/P1CDirectChannelCustomization.cs
+++ b/src/Skynet.Protocol/Packets/P1CDirectChannelCustomization.cs
@@ -11,7 +11,7 @@ namespace Skynet.Protocol.Packets
     [MessageFlags(MessageFlags.Loopback)]
     public sealed class P1CDirectChannelCustomization : ChannelMessage
     {
-        public string CustomNickname { get; set; }
+        public string? CustomNickname { get; set; }
         public ImageShape ProfileImageShape { get; set; }
         
         public override Packet Create() => new P1CDirectChannelCustomization().Init(this);

--- a/src/Skynet.Protocol/Packets/P1DGroupChannelKeyNotify.cs
+++ b/src/Skynet.Protocol/Packets/P1DGroupChannelKeyNotify.cs
@@ -12,8 +12,8 @@ namespace Skynet.Protocol.Packets
     public sealed class P1DGroupChannelKeyNotify : ChannelMessage
     {
         public long GroupChannelId { get; set; }
-        public byte[] NewKey { get; set; }
-        public byte[] HistoryKey { get; set; }
+        public byte[]? NewKey { get; set; }
+        public byte[]? HistoryKey { get; set; }
 
         public override Packet Create() => new P1DGroupChannelKeyNotify().Init(this);
 
@@ -31,12 +31,10 @@ namespace Skynet.Protocol.Packets
             buffer.WriteByteArray(HistoryKey, 64);
         }
 
-        protected override void DisposeMessage()
+        protected override void DisposeContents()
         {
-            base.DisposeMessage();
-
-            Array.Clear(NewKey, 0, NewKey.Length);
-            Array.Clear(HistoryKey, 0, HistoryKey.Length);
+            NewKey.AsSpan().Clear();
+            HistoryKey.AsSpan().Clear();
         }
     }
 }

--- a/src/Skynet.Protocol/Packets/P1EGroupChannelUpdate.cs
+++ b/src/Skynet.Protocol/Packets/P1EGroupChannelUpdate.cs
@@ -12,7 +12,7 @@ namespace Skynet.Protocol.Packets
     {
         public long GroupRevision { get; set; }
         public List<(long AccountId, GroupMemberFlags Flags)> Members { get; set; } = new List<(long AccountId, GroupMemberFlags Flags)>();
-        public byte[] KeyHistory { get; set; }
+        public byte[]? KeyHistory { get; set; }
 
         public override Packet Create() => new P1EGroupChannelUpdate().Init(this);
 

--- a/src/Skynet.Protocol/Packets/P20ChatMessage.cs
+++ b/src/Skynet.Protocol/Packets/P20ChatMessage.cs
@@ -13,7 +13,7 @@ namespace Skynet.Protocol.Packets
     public sealed class P20ChatMessage : ChannelMessage
     {
         public MessageType MessageType { get; set; }
-        public string Text { get; set; }
+        public string? Text { get; set; }
         public long QuotedMessageId { get; set; }
 
         public override Packet Create() => new P20ChatMessage().Init(this);

--- a/src/Skynet.Protocol/Packets/P21MessageOverride.cs
+++ b/src/Skynet.Protocol/Packets/P21MessageOverride.cs
@@ -13,7 +13,7 @@ namespace Skynet.Protocol.Packets
     public sealed class P21MessageOverride : ChannelMessage
     {
         public OverrideAction Action { get; set; }
-        public string NewText { get; set; }
+        public string? NewText { get; set; }
 
         public override Packet Create() => new P21MessageOverride().Init(this);
 

--- a/src/Skynet.Protocol/Packets/P24DaystreamMessage.cs
+++ b/src/Skynet.Protocol/Packets/P24DaystreamMessage.cs
@@ -13,7 +13,7 @@ namespace Skynet.Protocol.Packets
     public sealed class P24DaystreamMessage : ChannelMessage
     {
         public MessageType MessageType { get; set; }
-        public string Text { get; set; }
+        public string? Text { get; set; }
 
         public override Packet Create() => new P24DaystreamMessage().Init(this);
 

--- a/src/Skynet.Protocol/Packets/P25Nickname.cs
+++ b/src/Skynet.Protocol/Packets/P25Nickname.cs
@@ -10,7 +10,7 @@ namespace Skynet.Protocol.Packets
     [AllowedFlags(MessageFlags.Unencrypted)]
     public sealed class P25Nickname : ChannelMessage
     {
-        public string Nickname { get; set; }
+        public string? Nickname { get; set; }
 
         public override Packet Create() => new P25Nickname().Init(this);
 

--- a/src/Skynet.Protocol/Packets/P26Bio.cs
+++ b/src/Skynet.Protocol/Packets/P26Bio.cs
@@ -10,7 +10,7 @@ namespace Skynet.Protocol.Packets
     [AllowedFlags(MessageFlags.Unencrypted)]
     public sealed class P26Bio : ChannelMessage
     {
-        public string Bio { get; set; }
+        public string? Bio { get; set; }
 
         public override Packet Create() => new P26Bio().Init(this);
 

--- a/src/Skynet.Protocol/Packets/P27ProfileImage.cs
+++ b/src/Skynet.Protocol/Packets/P27ProfileImage.cs
@@ -10,7 +10,7 @@ namespace Skynet.Protocol.Packets
     [AllowedFlags(MessageFlags.Unencrypted | MessageFlags.MediaMessage | MessageFlags.ExternalFile)]
     public sealed class P27ProfileImage : ChannelMessage
     {
-        public string Caption { get; set; }
+        public string? Caption { get; set; }
 
         public override Packet Create() => new P27ProfileImage().Init(this);
 

--- a/src/Skynet.Protocol/Packets/P2DSearchAccount.cs
+++ b/src/Skynet.Protocol/Packets/P2DSearchAccount.cs
@@ -8,7 +8,7 @@ namespace Skynet.Protocol.Packets
     [Packet(0x2D, PacketPolicies.ClientToServer)]
     public sealed class P2DSearchAccount : Packet
     {
-        public string Query { get; set; }
+        public string? Query { get; set; }
 
         public override Packet Create() => new P2DSearchAccount().Init(this);
 

--- a/src/Skynet.Protocol/Skynet.Protocol.csproj
+++ b/src/Skynet.Protocol/Skynet.Protocol.csproj
@@ -2,9 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Copyright>© 2018-2020 Daniel Lerch, Twometer and Beniox</Copyright>
-    <Version>5.2.2</Version>
+    <Version>5.2.3</Version>
     <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
     <Authors>Daniel Lerch, Twometer, Beniox</Authors>
     <RepositoryUrl>https://github.com/skynet-im/skynet-dotnet</RepositoryUrl>

--- a/tests/Skynet.Core.Tests/Skynet.Core.Tests.csproj
+++ b/tests/Skynet.Core.Tests/Skynet.Core.Tests.csproj
@@ -1,11 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-
     <IsPackable>false</IsPackable>
-
     <RootNamespace>Skynet.Tests</RootNamespace>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Skynet.Protocol.Tests/ChannelMessageTests.cs
+++ b/tests/Skynet.Protocol.Tests/ChannelMessageTests.cs
@@ -55,7 +55,7 @@ namespace Skynet.Protocol.Tests
         {
             using var message = new FakeMessage { Text = text, MessageFlags = MessageFlags.Unencrypted };
 
-            byte[] content = message.PacketContent;
+            byte[]? content = message.PacketContent;
             Assert.IsNotNull(content);
             using var buffer = new PacketBuffer(content);
             Assert.AreEqual(text, buffer.ReadMediumString());
@@ -78,7 +78,7 @@ namespace Skynet.Protocol.Tests
                 AllowedFlags = MessageFlags.Unencrypted;
             }
 
-            public string Text { get; set; }
+            public string? Text { get; set; }
 
             public override Packet Create() => new FakeMessage();
 

--- a/tests/Skynet.Protocol.Tests/Cryptography/AesStaticTests.cs
+++ b/tests/Skynet.Protocol.Tests/Cryptography/AesStaticTests.cs
@@ -36,10 +36,10 @@ Dignissim convallis aenean et tortor at risus viverra adipiscing at.";
             byte[] hmacKey = new byte[32];
             byte[] aesKey = new byte[32];
 
-            Assert.ThrowsException<ArgumentNullException>(() => AesStatic.EncryptWithHmac(buffer, null, aesKey));
-            Assert.ThrowsException<ArgumentNullException>(() => AesStatic.EncryptWithHmac(buffer, hmacKey, null));
-            Assert.ThrowsException<ArgumentNullException>(() => AesStatic.DecryptWithHmac(buffer, null, aesKey));
-            Assert.ThrowsException<ArgumentNullException>(() => AesStatic.DecryptWithHmac(buffer, hmacKey, null));
+            Assert.ThrowsException<ArgumentNullException>(() => AesStatic.EncryptWithHmac(buffer, null!, aesKey));
+            Assert.ThrowsException<ArgumentNullException>(() => AesStatic.EncryptWithHmac(buffer, hmacKey, null!));
+            Assert.ThrowsException<ArgumentNullException>(() => AesStatic.DecryptWithHmac(buffer, null!, aesKey));
+            Assert.ThrowsException<ArgumentNullException>(() => AesStatic.DecryptWithHmac(buffer, hmacKey, null!));
         }
 
         [TestMethod]

--- a/tests/Skynet.Protocol.Tests/Skynet.Protocol.Tests.csproj
+++ b/tests/Skynet.Protocol.Tests/Skynet.Protocol.Tests.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-
     <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request enables the new C# 8.0 feature _nullable reference types_ for all projects.
Using `byte[].AsSpan().Clear()` instead of `Array.Clear(byte[], int, int)` avoids `NullReferenceExceptions` while disposing packets that have not been decrypted.